### PR TITLE
Add support for webpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,45 @@ bin/rails db:migrate
 ```
 to copy the migrations.
 
-Require the JavaScript (e.g. `//= require micro_cms`) and all styles (e.g. `@import 'micro_cms';'`).
-
 Mount the engine routes in you `config/routes.rb` file:
 ```ruby
 mount MicroCms::Engine => '/micro_cms'
 ```
+
+### Usage with Sprockets
+
+Require the JavaScript (e.g. `//= require micro_cms`) and all styles (e.g. `@import 'micro_cms';'`).
+
+### Usage with Webpacker
+
+Make sure that you import `rails/ujs` like that in your `application.js`:
+
+```js
+import Rails from '@rails/ujs';
+Rails.start();
+...
+window.Rails = Rails;
+```
+
+The last line makes the Rails scope global (since we inline the script, this is needed).
+
+Now you have to include the helper to your ApplicationHelper:
+
+```rb
+module ApplicationHelper
+  include MicroCms::ApplicationHelper
+  ...
+end
+```
+
+Now you can use the helper to inline the needed scripts via `app/views/layouts/application.html.slim`. It's strongly
+recommended to theck first, if the user is allowed to edit (but this is not part of this gem):
+
+```rb
+- if user_signed_in? # not part of this gem!
+  = micro_cms_asset_tags
+```
+
 
 ## Configuration
 `app/config/initializers/micro_cms.rb`:

--- a/app/helpers/micro_cms/application_helper.rb
+++ b/app/helpers/micro_cms/application_helper.rb
@@ -2,5 +2,19 @@
 
 module MicroCms
   module ApplicationHelper
+    # rubocop:disable Rails/OutputSafety
+    def micro_cms_asset_tags
+      js = load_gem_file 'micro_cms', 'app/assets/javascripts/micro_cms.js'
+      css = load_gem_file 'micro_cms', 'app/assets/stylesheets/micro_cms/micro_cms.css'
+      tag.script(js.html_safe) + tag.style(css)
+    end
+    # rubocop:enable Rails/OutputSafety
+
+    private
+
+    def load_gem_file(gem_name, assets_path)
+      path = File.join(Gem.loaded_specs[gem_name].full_gem_path, assets_path)
+      File.read(path)
+    end
   end
 end

--- a/spec/helpers/micro_cms/application_helper_spec.rb
+++ b/spec/helpers/micro_cms/application_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MicroCms::ApplicationHelper, type: :helper do
+  describe '#micro_cms_asset_tags' do
+    describe 'returns a script and css tag containing data from the micro_cms gem' do
+      subject { helper.micro_cms_asset_tags }
+
+      it { is_expected.to match(/<script>.*micro_cms.*<style>/m) }
+    end
+  end
+end


### PR DESCRIPTION
Since we had a problem yesterday with webpacker not working with the micro_cms, i found out that we had already a solution in another project. I would like to suggest to take that helper into the gem, so the integration is easier and less error-prone.